### PR TITLE
LSOA-111

### DIFF
--- a/templates/base/b4_base_with_nav.html
+++ b/templates/base/b4_base_with_nav.html
@@ -39,27 +39,27 @@
               <ul class="dropdown-menu">
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#chart_v1">Star Chart v1</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?chart_v1=Submit#chart_v1">Star Chart v1</a>
                 </li>
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#chart_v1_vertical">Star Chart v1 Vertical</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?chart_v1_vertical=Submit#chart_v1_vertical">Star Chart v1 Vertical</a>
                 </li>
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#chart_v2">Star Chart v2</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?chart_v2=Submit#chart_v2">Star Chart v2</a>
                 </li>
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#heat_map">Star Chart v2 Heat Map</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?heat_map=Submit#heat_map">Star Chart v2 Heat Map</a>
                 </li>
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#chart_v3">Star Chart v3</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?chart_v3=Submit#chart_v3">Star Chart v3</a>
                 </li>
                 <li>
                   <a class="dropdown-item chart-item"
-                    href="{% url 'observations_specific' request|course_from_session_or_first %}#chart_v4">Star Chart v4</a>
+                    href="{% url 'observations_specific' request|course_from_session_or_first %}?chart_v4=Submit#chart_v4">Star Chart v4</a>
                 </li>
               </ul>
             </li>

--- a/templates/observations.html
+++ b/templates/observations.html
@@ -290,7 +290,10 @@
       $('.nav-link').on('click', function (e) {
         var chart_href = $(this).attr('href');
         var chart_id = chart_href.substr(1);
-        $('#filtering-submit').attr('name', chart_id);
+
+        if (chart_href !== "#") {
+          $('#filtering-submit').attr('name', chart_id);
+        }
         
         if (chart_id == "chart_v3") {
           $("#construct-row").removeClass('d-none');


### PR DESCRIPTION
Fix bugs with star chart navigation.

I found two bugs there:
1) Selected star chart was removed in hidden element after selecting `Charts and Reports` option. 
2) When selecting one of the charts in dropdown navigation `star_chart1` was always taken as selected chart.

This should work fully with `feature/separated-classes-chart-2` branch.