### PR TITLE
Fix/filtering

### DIFF
--- a/kidviz/models.py
+++ b/kidviz/models.py
@@ -261,17 +261,15 @@ class Observation(TimeStampedModel, OwnerMixin):
             all_observations_for_chart_4 = observations
 
         if learning_constructs:
-            if LearningConstruct.NO_CONSTRUCT in learning_constructs:
-                observations = observations.filter(no_constructs=True)
-
             constructs = [
                 construct
                 for construct in learning_constructs
                 if construct != LearningConstruct.NO_CONSTRUCT
             ]
 
-            observations = observations.filter(
-                constructs__level__construct__id__in=constructs)
+            if LearningConstruct.NO_CONSTRUCT in learning_constructs:
+                observations = observations.filter(
+                    constructs__level__construct__id__in=constructs) | observations.filter(no_constructs=True)
 
         if date_from:
             observations = observations.filter(observation_date__gte=date_from)

--- a/kidviz/views.py
+++ b/kidviz/views.py
@@ -614,6 +614,10 @@ class ObservationAdminView(LoginRequiredMixin, TemplateView):
 
                 for sublevel in sublevels:
                     construct = sublevel.level.construct
+
+                    if construct not in constructs:
+                        continue
+
                     star_matrix[construct][student][sublevel].append(observation)
 
                     if observation.course:


### PR DESCRIPTION
## Description
Observation may be connected to many sublevels and with many constructs. The problem was if observation was associated with sublevel from filtered construct then the KeyError was raising. Besides that I've fixed wrong filtering of no_construct observations.