### PR TITLE
Add missing distinct in the work queue query

### DIFF
--- a/kidviz/views.py
+++ b/kidviz/views.py
@@ -1202,7 +1202,7 @@ class WorkQueue(LoginRequiredMixin, ListView):
         return Observation.objects.filter(
             Q(owner=self.request.user, constructs=None, is_draft=False) |
             Q(owner=self.request.user, is_draft=True)
-        )
+        ).distinct()
 
 
 class RemoveDraft(LoginRequiredMixin, View):


### PR DESCRIPTION
## Description
The work queue sometimes showed the duplicates of observations. To prevent that I've added distinct clause to the select query.